### PR TITLE
Use u8 to represent RGB

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ color.bold.cprintln('Hello World')
 import color
 
 brush := color.new_brush(
-    fg: color.rgb(0, 0, 0)!
-    bg: color.hex(0xffffff)!
+    fg: color.rgb(0, 0, 0)
+    bg: color.hex(0xffffff)
     style: [color.bold, color.underline, color.italic]
 )!
 

--- a/color/true_color.v
+++ b/color/true_color.v
@@ -2,11 +2,7 @@ module color
 
 import term
 
-pub fn rgb(r int, g int, b int) !Color {
-	if r < 0 || r > 255 || g < 0 || g > 255 || b < 0 || b > 255 {
-		return error('Red, green and blue must each be between 0 and 255')
-	}
-
+pub fn rgb(r u8, g u8, b u8) Color {
 	return TrueColor{
 		r: r
 		g: g
@@ -14,14 +10,14 @@ pub fn rgb(r int, g int, b int) !Color {
 	}
 }
 
-pub fn hex(hex int) !Color {
-	return rgb(hex >> 16, hex >> 8 & 0xFF, hex & 0xFF)!
+pub fn hex(hex int) Color {
+	return rgb(u8(hex >> 16), u8(hex >> 8 & 0xFF), u8(hex & 0xFF))
 }
 
 struct TrueColor {
-	r int
-	g int
-	b int
+	r u8
+	g u8
+	b u8
 }
 
 fn (c TrueColor) render(msg string) string {

--- a/color/true_color.v
+++ b/color/true_color.v
@@ -21,9 +21,9 @@ struct TrueColor {
 }
 
 fn (c TrueColor) render(msg string) string {
-	return term.rgb(c.r, c.g, c.b, msg)
+	return term.rgb(int(c.r), int(c.g), int(c.b), msg)
 }
 
 fn (c TrueColor) render_bg(msg string) string {
-	return term.bg_rgb(c.r, c.g, c.b, msg)
+	return term.bg_rgb(int(c.r), int(c.g), int(c.b), msg)
 }

--- a/color/true_color.v
+++ b/color/true_color.v
@@ -21,9 +21,9 @@ struct TrueColor {
 }
 
 fn (c TrueColor) render(msg string) string {
-	return term.rgb(int(c.r), int(c.g), int(c.b), msg)
+	return term.rgb(c.r, c.g, c.b, msg)
 }
 
 fn (c TrueColor) render_bg(msg string) string {
-	return term.bg_rgb(int(c.r), int(c.g), int(c.b), msg)
+	return term.bg_rgb(c.r, c.g, c.b, msg)
 }


### PR DESCRIPTION
- Use `u8` to represent RGB fields in `TrueColor`
- Accept `u8` instead of `int` and remove the range check
- Update example in README